### PR TITLE
Fix link to (and name of) Dashes

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -23,4 +23,5 @@ I keep a few other places alive:
 
 - **[Brackets](https://brackets.passcod.name)** — A page of brackets
 - **[Dashes](https://dashes.passcod.name)** — A page of dashes
+- **[Tildes](https://tildes.passcod.name)** — A page of tildes
 - **[Mechanical Bird](https://mechanicalbird.surge.sh)** — A simple browser-based time tracker

--- a/src/intro.md
+++ b/src/intro.md
@@ -22,5 +22,5 @@ an archive, a list of projects, and various information about and around me. Hav
 I keep a few other places alive:
 
 - **[Brackets](https://brackets.passcod.name)** — A page of brackets
-- **[Dash](https://dash.passcod.name)** — A page of dashes
+- **[Dashes](https://dashes.passcod.name)** — A page of dashes
 - **[Mechanical Bird](https://mechanicalbird.surge.sh)** — A simple browser-based time tracker


### PR DESCRIPTION
https://dash.passcod.name returns `NXDOMAIN`, but https://dashes.passcod.name works and seems like the right thing... I also changed the link text to match the DNS name.

I just noticed that *Tildes* also exists, but I don't feel like cancelling and editing my commit :stuck_out_tongue: